### PR TITLE
Fix error handling in scheduled reboot

### DIFF
--- a/server/services/scheduler.ts
+++ b/server/services/scheduler.ts
@@ -120,7 +120,7 @@ class RebootSchedulerService {
           } catch (error) {
             console.error('[Scheduler] Scheduled reboot error:', error);
           }
-        }));
+        });
       } else {
         console.error(`[Scheduler] Invalid cron expression for day ${day}: ${cronExpression}`);
       }


### PR DESCRIPTION
A syntax error occurred in the file server/services/scheduler.ts at line 123 during the build process. The issue was caused by an extra closing parenthesis ) in the code, resulting in a )) sequence. Because of this, the TypeScript/JavaScript parser expected the end of the statement (typically a semicolon ;) but instead encountered an additional closing parenthesis.

This mismatch in parentheses broke the syntax structure of the expression and prevented the code from compiling correctly.

Cause

The error happened because a function call or expression was closed twice, leaving one unnecessary ).

Fix

The problem was resolved by removing the extra closing parenthesis so that the parentheses are correctly balanced and the statement ends properly.