### PR TITLE
feat: integrate MCP server as optional Docker Compose profile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mcp-server"]
+	path = mcp-server
+	url = https://github.com/leto1210/mafreebox-mcpserver.git

--- a/README.md
+++ b/README.md
@@ -191,6 +191,64 @@ L'image Docker est configuree avec les bonnes pratiques de securite :
 
 Merci à [Loule95450](https://github.com/Loule95450) & [Rayandri](https://github.com/Rayandri) pour la pull-request.
 
+## Integration MCP — Piloter la Freebox via Claude AI (Optionnel)
+
+Le dashboard peut etre complete par un serveur [MCP (Model Context Protocol)](https://github.com/leto1210/mafreebox-mcpserver) qui permet de piloter votre Freebox en langage naturel depuis **Claude Desktop**.
+
+Exemples de commandes possibles :
+- *"Quels appareils sont connectes en ce moment ?"*
+- *"Montre-moi les telechargements en cours"*
+- *"Quelle est la temperature de ma Freebox ?"*
+- *"Ouvre le port 8080 vers mon serveur 192.168.1.10"*
+- *"Demarre la VM Ubuntu"*
+
+### Activation
+
+Le serveur MCP est un **profil Docker Compose optionnel** — les utilisateurs qui n'en veulent pas ne sont pas impactes.
+
+```bash
+# Production (image pre-construite)
+docker-compose --profile mcp up -d
+
+# Developpement local (build depuis les sources)
+docker-compose -f docker-compose.local.yml --profile mcp up -d --build
+```
+
+### Configuration Claude Desktop
+
+Editez le fichier de configuration Claude Desktop :
+- **macOS** : `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows** : `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "freebox": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-v", "freebox_mcp_data:/app/data",
+        "-e", "FREEBOX_HOST=mafreebox.freebox.fr",
+        "ghcr.io/leto1210/mafreebox-mcpserver:latest"
+      ]
+    }
+  }
+}
+```
+
+> **`-i` et non `-it`** : Claude Desktop communique via stdio sans TTY.
+
+### Premiere connexion MCP
+
+1. Dans Claude Desktop, demandez : **"Connecte-toi a ma Freebox"**
+2. Claude appellera `freebox_authorize`
+3. **Sur votre Freebox** : un message s'affiche sur l'ecran LCD
+4. **Appuyez sur `>`** pour autoriser l'application
+5. Demandez a Claude : **"Verifie si l'autorisation est accordee"**
+6. Le token est sauvegarde — les prochaines sessions sont automatiques
+
+> Pour plus de details, consultez le [README du serveur MCP](https://github.com/leto1210/mafreebox-mcpserver).
+
 ## Premiere connexion
 
 Au premier lancement, vous devrez autoriser l'application sur la Freebox :

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,6 +36,24 @@ services:
       - freebox_dashboard_data_dev:/app/data
     restart: unless-stopped
 
+  # MCP Server (optional) — Claude AI integration
+  freebox-mcp:
+    build:
+      context: ./mcp-server
+      dockerfile: Dockerfile
+    container_name: freebox-mcp-dev
+    restart: unless-stopped
+    profiles:
+      - mcp
+    environment:
+      - FREEBOX_HOST=${FREEBOX_HOST:-mafreebox.freebox.fr}
+      - FREEBOX_TOKEN_FILE=/app/data/freebox_token.json
+      - DEBUG=1
+    volumes:
+      - freebox_mcp_data_dev:/app/data
+
 volumes:
   freebox_dashboard_data_dev:
     name: freebox_dashboard_data_dev
+  freebox_mcp_data_dev:
+    name: freebox_mcp_data_dev

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -58,6 +58,26 @@ services:
     #       cpus: '0.5'
     #       memory: 256M
 
+  # ===========================================
+  # MCP Server (optional) — Claude AI integration
+  # ===========================================
+  # Activate with: docker-compose -f docker-compose.local.yml --profile mcp up -d --build
+  freebox-mcp:
+    build:
+      context: ./mcp-server
+      dockerfile: Dockerfile
+    container_name: freebox-mcp-local
+    restart: unless-stopped
+    profiles:
+      - mcp
+    environment:
+      - FREEBOX_HOST=${FREEBOX_HOST:-mafreebox.freebox.fr}
+      - FREEBOX_TOKEN_FILE=/app/data/freebox_token.json
+    volumes:
+      - freebox_mcp_data:/app/data
+
 volumes:
   freebox_dashboard_data:
     name: freebox_dashboard_data_local
+  freebox_mcp_data:
+    name: freebox_mcp_data_local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@
 # Examples:
 #   DASHBOARD_PORT=8080 docker-compose up -d
 #   docker-compose --env-file .env up -d
+#
+# MCP Server (optional — Claude AI integration):
+#   docker-compose --profile mcp up -d
 
 services:
   freebox-dashboard:
@@ -63,7 +66,27 @@ services:
     #       cpus: '0.1'
     #       memory: 128M
 
-# Named volume for persistent token storage
+  # ===========================================
+  # MCP Server (optional) — Claude AI integration
+  # ===========================================
+  # Activate with: docker-compose --profile mcp up -d
+  # See: https://github.com/leto1210/mafreebox-mcpserver
+  freebox-mcp:
+    image: ghcr.io/leto1210/mafreebox-mcpserver:latest
+    container_name: freebox-mcp
+    restart: unless-stopped
+    profiles:
+      - mcp
+    environment:
+      - FREEBOX_HOST=${FREEBOX_HOST:-mafreebox.freebox.fr}
+      - FREEBOX_TOKEN_FILE=/app/data/freebox_token.json
+    volumes:
+      - freebox_mcp_data:/app/data
+    # MCP servers communicate via stdio — no ports exposed
+
+# Named volumes for persistent token storage
 volumes:
   freebox_data:
     name: freebox_dashboard_data
+  freebox_mcp_data:
+    name: freebox_mcp_data


### PR DESCRIPTION
## Summary

Intègre le serveur [mafreebox-mcpserver](https://github.com/leto1210/mafreebox-mcpserver) comme composant optionnel du dashboard, permettant de piloter la Freebox en langage naturel depuis Claude Desktop.

- Ajout du serveur MCP en **git submodule** sous `mcp-server/`
- Configuration comme **service optionnel** dans les 3 fichiers docker-compose (prod, local, dev) via le profil `mcp`
- Ajout d'une **section README** avec instructions d'activation, configuration Claude Desktop, et première connexion

### Activation

```bash
# Les utilisateurs qui n'en veulent pas ne sont pas impactés
docker-compose --profile mcp up -d
```

### Impact

- **Aucun changement** pour les utilisateurs existants (le profil `mcp` est opt-in)
- Le volume `freebox_mcp_data` persiste le token d'auth MCP indépendamment du dashboard
- Le mode dev inclut `DEBUG=1` par défaut pour faciliter le troubleshooting

Closes #65

## Test plan

- [ ] Vérifier que `docker-compose up -d` (sans `--profile mcp`) fonctionne comme avant
- [ ] Vérifier que `docker-compose --profile mcp up -d` démarre le service MCP
- [ ] Tester la connexion depuis Claude Desktop avec la config JSON documentée
- [ ] Vérifier la première autorisation (appui sur `>` sur l'écran LCD de la Freebox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)