### PR TITLE
fix(docker): pre-bundle server to fix esbuild platform mismatch on ARM64

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ npm-debug.log*
 
 # Build output (will be rebuilt in container)
 dist/
+dist-server/
 
 # Development files
 .git/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-server
 dist-ssr
 *.local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,12 @@
 # Multi-stage build for production deployment
 # ===========================================
 
-# Stage 1: Build frontend (native platform for speed)
+# Stage 1: Build frontend AND bundle backend (native platform for speed)
+# The server is pre-compiled to plain JavaScript via esbuild so the
+# production image does NOT need tsx/esbuild at runtime. This fixes the
+# multi-arch "You installed esbuild for another platform" crash on ARM64
+# hosts (Freebox Ultra VM, Raspberry Pi, Apple Silicon) that hit issue #69
+# after #63.
 FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
 
 WORKDIR /app
@@ -19,7 +24,7 @@ COPY . .
 ARG VITE_LOGO_DEV_TOKEN
 ENV VITE_LOGO_DEV_TOKEN=$VITE_LOGO_DEV_TOKEN
 
-# Build frontend (Vite)
+# Build frontend (Vite -> dist/) AND bundle backend (esbuild -> dist-server/index.js)
 RUN npm run build
 
 # Stage 2: Install production dependencies on native platform
@@ -31,6 +36,8 @@ COPY package*.json ./
 RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 
 # Stage 3: Production image (target platform)
+# Runs plain Node on a pre-bundled JS entrypoint — no TypeScript, no tsx,
+# no native esbuild binary required at runtime.
 FROM node:20-alpine AS production
 
 # Security: Create non-root user
@@ -46,12 +53,9 @@ RUN mkdir -p /app/data && chown -R freebox:nodejs /app/data
 COPY --chown=freebox:nodejs package*.json ./
 COPY --chown=freebox:nodejs --from=deps /app/node_modules ./node_modules
 
-# Copy built frontend from builder
+# Copy built frontend and pre-bundled backend from builder
 COPY --chown=freebox:nodejs --from=builder /app/dist ./dist
-
-# Copy backend source (TypeScript files - tsx runs them directly)
-COPY --chown=freebox:nodejs --from=builder /app/server ./server
-COPY --chown=freebox:nodejs --from=builder /app/tsconfig.json ./
+COPY --chown=freebox:nodejs --from=builder /app/dist-server ./dist-server
 
 # Environment variables with defaults
 ENV NODE_ENV=production
@@ -69,5 +73,5 @@ USER freebox
 # Expose port
 EXPOSE 3000
 
-# Start the server directly with tsx (not through npm to avoid double process)
-CMD ["node_modules/.bin/tsx", "server/index.ts"]
+# Run the pre-bundled server directly with Node (no tsx, no runtime transpile)
+CMD ["node", "dist-server/index.js"]

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:client": "vite",
     "dev:server": "tsx watch server/index.ts",
-    "build": "vite build",
+    "build": "npm run build:client && npm run build:server",
+    "build:client": "vite build",
+    "build:server": "esbuild server/index.ts --bundle --platform=node --target=node20 --format=esm --packages=external --outfile=dist-server/index.js",
     "start": "cross-env NODE_ENV=production tsx server/index.ts",
+    "start:prod": "cross-env NODE_ENV=production node dist-server/index.js",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Résumé

Ferme l'issue #69 (et règle le même symptôme rapporté dans #63 sur un autre chemin).

L'image Docker plantait au démarrage sur les hôtes **ARM64** (VM Alpine Freebox Ultra, Raspberry Pi, Mac Apple Silicon) avec :

\`\`\`
Error [TransformError]:
You installed esbuild for another platform than the one you're currently using.
Specifically the "@esbuild/linux-x64" package is present but this platform
needs the "@esbuild/linux-arm64" package instead.
\`\`\`

## Root cause

Le \`CMD\` de production utilise \`tsx server/index.ts\` → \`tsx\` charge un binaire natif \`@esbuild/linux-<arch>\` pour transpiler le TypeScript à la volée au démarrage. Dans le workflow \`docker-publish.yml\`, le build se fait en multi-arch (\`linux/amd64,linux/arm64\`) via \`buildx\` + QEMU. Le stage 2 du \`Dockerfile\` (\`FROM node:20-alpine AS production\`) tourne en émulation QEMU pour la cible ARM64 ; dans cette émulation, \`npm ci --ignore-scripts\` résout parfois la mauvaise \`optionalDependency\` esbuild et installe \`@esbuild/linux-x64\` dans une image ARM64 → crash au boot.

## Fix

Pré-compiler le serveur TypeScript en un bundle JavaScript unique au **build time** (Stage 1, sur le \`BUILDPLATFORM\` natif où esbuild fonctionne toujours), puis exécuter du Node pur sur ce bundle en production. L'image runtime ne contient plus **ni \`tsx\`, ni \`typescript\`, ni aucun binaire natif esbuild** → aucune dépendance platform-specific à l'exécution, aucun mismatch possible.

### Changements

- **\`package.json\`** : ajout du script \`build:server\` (bundle esbuild ESM avec \`--packages=external\`), \`build\` enchaîne désormais client + server, nouveau \`start:prod\` qui lance \`node dist-server/index.js\`.
- **\`Dockerfile\`** : le Stage 1 produit \`dist/\` (Vite) et \`dist-server/index.js\` (esbuild). Le Stage 2 copie les deux, installe uniquement les dépendances runtime en JS pur (\`express\`, \`cors\`, \`ws\`, \`node-cron\`, \`dotenv\`, \`form-data\`) et lance \`node dist-server/index.js\` — plus de \`tsx\` à l'exécution.
- **\`.dockerignore\`** + **\`.gitignore\`** : exclusion du nouvel artefact \`dist-server/\`.

### Bénéfices secondaires

- **Démarrage plus rapide** : plus de transpile TS au boot.
- **Image runtime plus légère** : suppression de \`tsx\` + esbuild + typescript des prod deps implicites.
- **Fiabilité multi-arch** : le problème ne peut plus réapparaître — il n'y a plus de binaire natif dans la couche runtime.

### Non-changé

- Le workflow dev (\`npm run dev\`, \`tsx watch\`) est inchangé.
- \`Dockerfile.dev\` est inchangé.
- Aucun changement de comportement fonctionnel — mêmes routes, même WebSocket, même static serve SPA.

## Test plan

- [x] \`npm run build\` → produit \`dist/\` (1 MB client) et \`dist-server/index.js\` (123 kB server)
- [x] \`NODE_ENV=production node dist-server/index.js\` → serveur démarre, banner affichée
- [x] \`GET /api/health\` → 200 \`{"status":"ok",...}\`
- [x] \`GET /\` → 200 (SPA \`index.html\` servie)
- [x] WebSocket server initialisé sans erreur
- [ ] (CI) Docker buildx \`linux/amd64,linux/arm64\` du workflow PR doit passer sans crash — la vraie cible de cette PR.
- [ ] (À tester par @RGFRv2) lancement du conteneur sur VM Alpine ARM64 (Freebox Ultra) → le crash \`TransformError\` ne doit plus apparaître.

Fixes #69
Refs #63