### PR TITLE
fix(wifi): show both 5GHz radios on Freebox Ultra (#10)

### DIFF
--- a/src/stores/wifiStore.ts
+++ b/src/stores/wifiStore.ts
@@ -113,6 +113,13 @@ export const useWifiStore = create<WifiState>((set, get) => ({
         // For Freebox v9+, BSS contains band info directly in status
         for (const b of bss || []) {
           if (b.config?.enabled) {
+            // Skip secondary BSSes (e.g. guest networks broadcast on the same
+            // radio as the main one) — they share the SSID with the main BSS
+            // and would otherwise be deduped randomly. `is_main_bss === false`
+            // is the explicit signal; older API responses leave the field
+            // undefined, in which case we keep the BSS.
+            if (b.status?.is_main_bss === false) continue;
+
             // Get band from BSS status (Freebox v9+) or try to find matching AP
             let band: '2.4GHz' | '5GHz' | '6GHz' = '2.4GHz';
 
@@ -127,8 +134,11 @@ export const useWifiStore = create<WifiState>((set, get) => ({
               }
             }
 
-            // Only add one network per band (they share SSID)
-            const bandKey = `${b.config.ssid}-${band}`;
+            // Dedup per physical radio (phy_id + band). The Freebox Ultra
+            // exposes TWO distinct 5GHz radios (e.g. one 80 MHz + one 160 MHz)
+            // that share the same SSID — keying by `ssid` would drop one of
+            // them non-deterministically. See issue #10.
+            const bandKey = `${b.phy_id}-${band}`;
             if (!seenBands.has(bandKey)) {
               seenBands.add(bandKey);
 


### PR DESCRIPTION
## Summary

- Closes #10 — only one of the Freebox Ultra's two 5 GHz radios was rendered, and which one appeared was non-deterministic (depends on BSS iteration order from the API).
- The two 5 GHz radios of the Ultra share the same SSID, so the previous dedup key `\${ssid}-\${band}` collapsed them into a single entry.

## Changes (`src/stores/wifiStore.ts`)

1. **Skip secondary BSSes** when `b.status.is_main_bss === false`. Without this, a guest network broadcast on the same radio could take the slot of the main one when iteration order is reversed. Older API responses without `is_main_bss` keep the previous behavior (field undefined ⇒ kept).
2. **Dedup by `\${phy_id}-\${band}`** instead of `\${ssid}-\${band}`. Each physical radio has a unique `phy_id`, so the two 5 GHz cards of the Ultra are now both preserved, while a single radio with multiple BSSes still appears only once per band.

Single-radio Freeboxes (Pop, Delta, Revolution, …) keep one entry per band as before — `phy_id` is unique per physical card and there is only one card per band on those models.

## How it relates to the issue thread

- @JeuFore confirmed (when forcing both radios on) that the API returns the 4 BSSes — the fix lets all 4 reach the rendered list.
- @pquantin saw only the 80 MHz card, @yarez0 only the 160 MHz one — this matches the non-deterministic dedup of `\${ssid}-\${band}`.

## Test plan

- [x] `npm run build` (vite build): PASS — 2375 modules transformed.
- [ ] Manual check on a Freebox Ultra with both 5 GHz radios enabled: should display two 5 GHz cards (one per radio) with their respective channel widths.
- [ ] Manual check on a Pop / Delta with a single 5 GHz radio: should display one 5 GHz card as before.
- [ ] Manual check on an Ultra in eco mode (one 5 GHz radio active, one disabled): the disabled radio's BSS has `config.enabled = false` and is already filtered upstream, so a single 5 GHz card is displayed (current behavior preserved).

I do not have a Freebox Ultra at hand to validate live — happy to iterate if a maintainer or a user from the issue thread can confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)