### PR TITLE
chore: bump mcp-server to v1.5.0 (116 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Merci à [Loule95450](https://github.com/Loule95450) & [Rayandri](https://github
 
 ## Integration MCP — Piloter la Freebox via Claude AI (Optionnel)
 
-Le dashboard peut etre complete par un serveur [MCP (Model Context Protocol)](https://github.com/leto1210/mafreebox-mcpserver) qui permet de piloter votre Freebox en langage naturel depuis **Claude Desktop**.
+Le dashboard peut etre complete par un serveur [MCP (Model Context Protocol)](https://github.com/leto1210/mafreebox-mcpserver) qui permet de piloter votre Freebox en langage naturel depuis **Claude Desktop**. La version actuelle (v1.5.0) expose **116 outils** couvrant la quasi-totalite de l'API Freebox OS.
 
 Exemples de commandes possibles :
 - *"Quels appareils sont connectes en ce moment ?"*
@@ -204,6 +204,9 @@ Exemples de commandes possibles :
 - *"Quelle est la temperature de ma Freebox ?"*
 - *"Ouvre le port 8080 vers mon serveur 192.168.1.10"*
 - *"Demarre la VM Ubuntu"*
+- *"Cree un repertoire sur le disque Freebox"*
+- *"Montre-moi la configuration IPv6"*
+- *"Liste les distributions VM disponibles"*
 
 ### Activation
 
@@ -232,7 +235,7 @@ Editez le fichier de configuration Claude Desktop :
         "run", "--rm", "-i",
         "-v", "freebox_mcp_data:/app/data",
         "-e", "FREEBOX_HOST=mafreebox.freebox.fr",
-        "ghcr.io/leto1210/mafreebox-mcpserver:latest"
+        "ghcr.io/leto1210/mafreebox-mcpserver:v1.5.0"
       ]
     }
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
   # Activate with: docker-compose --profile mcp up -d
   # See: https://github.com/leto1210/mafreebox-mcpserver
   freebox-mcp:
-    image: ghcr.io/leto1210/mafreebox-mcpserver:latest
+    image: ghcr.io/leto1210/mafreebox-mcpserver:v1.5.0
     container_name: freebox-mcp
     restart: unless-stopped
     profiles:


### PR DESCRIPTION
## Summary

- Bump `mcp-server` submodule from v1.1.1 to v1.5.0
- Pin Docker image to `ghcr.io/leto1210/mafreebox-mcpserver:v1.5.0`
- Update README with new tool count (116) and example commands

## What's new in MCP Server v1.5.0

**26 new tools** synced from this dashboard's API surface (90 → 116 tools):

- **Phase 9**: File system operations (info, mkdir, rename, move, copy, delete, hash) + 3 existing methods wired to tools
- **Phase 10**: Connection & network config (connection config/logs, IPv6, FTTH, LAN config, notifications, port forwarding update)
- **Phase 11**: WiFi & VM advanced (MAC filter, temp disable, MLO/WiFi 7, VM create/delete/restart/distros)

Full changelog: https://github.com/leto1210/mafreebox-mcpserver/releases/tag/v1.5.0

## Test plan

- [ ] `docker compose --profile mcp up -d` pulls v1.5.0 image correctly
- [ ] `docker compose -f docker-compose.local.yml --profile mcp up -d --build` builds from submodule
- [ ] MCP server exposes 116 tools via `tools/list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)